### PR TITLE
2 small QOL features for GUITextbox

### DIFF
--- a/Scripts/ShapeEditor/Gui/GuiFloatTextbox.cs
+++ b/Scripts/ShapeEditor/Gui/GuiFloatTextbox.cs
@@ -72,12 +72,6 @@ namespace AeternumGames.ShapeEditor
         // whitelist the input characters related to floating point numbers and math.
         protected override bool ValidateCharacter(char character)
         {
-            return (ValidateNumber(character) || ValidateOther(character));
-        }
-
-        // whitelist all number characters
-        private static bool ValidateNumber(char character)
-        {
             switch (character)
             {
                 case '0':
@@ -90,16 +84,6 @@ namespace AeternumGames.ShapeEditor
                 case '7':
                 case '8':
                 case '9':
-                    return true;
-            }
-            return false;
-        }
-
-        // whitelist any non-integer math related characters
-        private static bool ValidateOther(char character)
-        {
-            switch (character)
-            {
                 case '.':
                 case '-':
                 case '+':
@@ -114,7 +98,7 @@ namespace AeternumGames.ShapeEditor
             }
             return false;
         }
-        
+
         /// <summary>
         /// Parses and modifies the number so that it's valid for the rules of this textbox.
         /// </summary>

--- a/Scripts/ShapeEditor/Gui/GuiFloatTextbox.cs
+++ b/Scripts/ShapeEditor/Gui/GuiFloatTextbox.cs
@@ -18,8 +18,6 @@ namespace AeternumGames.ShapeEditor
 
         /// <summary>Whether negative numbers are supported.</summary>
         public bool allowNegativeNumbers = true;
-        /// <summary>Whether the contents update every time a character is added.</summary>
-        public bool autoUpdateOnInput;
         /// <summary>The value must be at least this number.</summary>
         public float minValue = float.MinValue;
         /// <summary>The value must be at most this number.</summary>
@@ -152,7 +150,6 @@ namespace AeternumGames.ShapeEditor
         {
             // store a copy of the text before the edit.
             textBeforeEdit = text;
-            base.OnFocus();
         }
 
         public override void OnFocusLost()
@@ -169,9 +166,7 @@ namespace AeternumGames.ShapeEditor
                 OnFinishEdit();
             }
 
-            bool returnValue = base.OnKeyDown(keyCode);
-            if (autoUpdateOnInput && !ValidateOther(Event.current.character)) OnFinishEdit();
-            return returnValue;
+            return base.OnKeyDown(keyCode);
         }
     }
 }

--- a/Scripts/ShapeEditor/Gui/GuiFloatTextbox.cs
+++ b/Scripts/ShapeEditor/Gui/GuiFloatTextbox.cs
@@ -18,6 +18,8 @@ namespace AeternumGames.ShapeEditor
 
         /// <summary>Whether negative numbers are supported.</summary>
         public bool allowNegativeNumbers = true;
+        /// <summary>Whether the contents update every time a character is added.</summary>
+        public bool autoUpdateOnInput;
         /// <summary>The value must be at least this number.</summary>
         public float minValue = float.MinValue;
         /// <summary>The value must be at most this number.</summary>
@@ -72,6 +74,12 @@ namespace AeternumGames.ShapeEditor
         // whitelist the input characters related to floating point numbers and math.
         protected override bool ValidateCharacter(char character)
         {
+            return (ValidateNumber(character) || ValidateOther(character));
+        }
+
+        // whitelist all number characters
+        private static bool ValidateNumber(char character)
+        {
             switch (character)
             {
                 case '0':
@@ -84,6 +92,16 @@ namespace AeternumGames.ShapeEditor
                 case '7':
                 case '8':
                 case '9':
+                    return true;
+            }
+            return false;
+        }
+
+        // whitelist any non-integer math related characters
+        private static bool ValidateOther(char character)
+        {
+            switch (character)
+            {
                 case '.':
                 case '-':
                 case '+':
@@ -98,11 +116,11 @@ namespace AeternumGames.ShapeEditor
             }
             return false;
         }
-
+        
         /// <summary>
         /// Parses and modifies the number so that it's valid for the rules of this textbox.
         /// </summary>
-        /// <param name="number">The number to be checked.</param>
+        /// <param name="text">The number to be checked.</param>
         /// <returns>The corrected number or the same number.</returns>
         private float ParseAndValidateNumber(string text)
         {
@@ -134,6 +152,7 @@ namespace AeternumGames.ShapeEditor
         {
             // store a copy of the text before the edit.
             textBeforeEdit = text;
+            base.OnFocus();
         }
 
         public override void OnFocusLost()
@@ -145,12 +164,14 @@ namespace AeternumGames.ShapeEditor
         public override bool OnKeyDown(KeyCode keyCode)
         {
             // pressing the enter key could mean the user finished an edit.
-            if (keyCode == KeyCode.Return)
+            if (keyCode == KeyCode.Return || keyCode == KeyCode.KeypadEnter)
             {
                 OnFinishEdit();
             }
 
-            return base.OnKeyDown(keyCode);
+            bool returnValue = base.OnKeyDown(keyCode);
+            if (autoUpdateOnInput && !ValidateOther(Event.current.character)) OnFinishEdit();
+            return returnValue;
         }
     }
 }

--- a/Scripts/ShapeEditor/Gui/GuiTextbox.cs
+++ b/Scripts/ShapeEditor/Gui/GuiTextbox.cs
@@ -43,8 +43,6 @@ namespace AeternumGames.ShapeEditor
         public int maxLength = 32767;
         /// <summary>Whether this textbox accepts text input.</summary>
         public bool isReadonly;
-        /// <summary>Whether all contents are selected upon focus gained.</summary>
-        public bool selectAllOnFocus;
         /// <summary>The textbox font.</summary>
         public BmFont font;
 
@@ -87,22 +85,25 @@ namespace AeternumGames.ShapeEditor
 
         public override void OnMouseDown(int button)
         {
-            if (button == 0)
+            switch (button)
             {
-                // avoid interference with focus gain
-                if (selectAllOnFocus) return;
+                case 1:
+                    CaretSelectAll();
+                    break;
                 
-                // set the caret position.
-                caretCharPosition = TextXToCaretCharPosition(Mathf.RoundToInt(editor.mousePosition.x));
+                default:
+                    // set the caret position.
+                    caretCharPosition = TextXToCaretCharPosition(Mathf.RoundToInt(editor.mousePosition.x));
 
-                // set the selection position.
-                SelectionSet(caretCharPosition, caretCharPosition);
+                    // set the selection position.
+                    SelectionSet(caretCharPosition, caretCharPosition);
 
-                // reset the caret blink timer.
-                CaretResetBlink();
+                    // reset the caret blink timer.
+                    CaretResetBlink();
 
-                // set the selection end position.
-                SelectionSetEnd(caretCharPosition);
+                    // set the selection end position.
+                    SelectionSetEnd(caretCharPosition);
+                    break;
             }
         }
 
@@ -110,9 +111,6 @@ namespace AeternumGames.ShapeEditor
         {
             if (button == 0)
             {
-                // avoid interference with focus gain
-                if (selectAllOnFocus) return;
-
                 // automatic scrolling when the mouse moves (for the edges on long text).
 
                 // set the caret position.
@@ -220,12 +218,6 @@ namespace AeternumGames.ShapeEditor
             if (editor.isCtrlPressed && keyCode == KeyCode.X) CaretCut();
 
             return true; // true everything, we are typing!
-        }
-
-        public override void OnFocus()
-        {
-            base.OnFocus();
-            if (selectAllOnFocus) CaretSelectAll();
         }
 
         /// <summary>Can be used by child classes to whitelist or blacklist characters.</summary>

--- a/Scripts/ShapeEditor/Gui/GuiTextbox.cs
+++ b/Scripts/ShapeEditor/Gui/GuiTextbox.cs
@@ -43,6 +43,8 @@ namespace AeternumGames.ShapeEditor
         public int maxLength = 32767;
         /// <summary>Whether this textbox accepts text input.</summary>
         public bool isReadonly;
+        /// <summary>Whether all contents are selected upon focus gained.</summary>
+        public bool selectAllOnFocus;
         /// <summary>The textbox font.</summary>
         public BmFont font;
 
@@ -87,6 +89,9 @@ namespace AeternumGames.ShapeEditor
         {
             if (button == 0)
             {
+                // avoid interference with focus gain
+                if (selectAllOnFocus) return;
+                
                 // set the caret position.
                 caretCharPosition = TextXToCaretCharPosition(Mathf.RoundToInt(editor.mousePosition.x));
 
@@ -105,6 +110,9 @@ namespace AeternumGames.ShapeEditor
         {
             if (button == 0)
             {
+                // avoid interference with focus gain
+                if (selectAllOnFocus) return;
+
                 // automatic scrolling when the mouse moves (for the edges on long text).
 
                 // set the caret position.
@@ -212,6 +220,12 @@ namespace AeternumGames.ShapeEditor
             if (editor.isCtrlPressed && keyCode == KeyCode.X) CaretCut();
 
             return true; // true everything, we are typing!
+        }
+
+        public override void OnFocus()
+        {
+            base.OnFocus();
+            if (selectAllOnFocus) CaretSelectAll();
         }
 
         /// <summary>Can be used by child classes to whitelist or blacklist characters.</summary>

--- a/Scripts/ShapeEditor/Gui/GuiTextbox.cs
+++ b/Scripts/ShapeEditor/Gui/GuiTextbox.cs
@@ -85,25 +85,24 @@ namespace AeternumGames.ShapeEditor
 
         public override void OnMouseDown(int button)
         {
-            switch (button)
+            if (button == 0)
             {
-                case 1:
-                    CaretSelectAll();
-                    break;
-                
-                default:
-                    // set the caret position.
-                    caretCharPosition = TextXToCaretCharPosition(Mathf.RoundToInt(editor.mousePosition.x));
+                // set the caret position.
+                caretCharPosition = TextXToCaretCharPosition(Mathf.RoundToInt(editor.mousePosition.x));
 
-                    // set the selection position.
-                    SelectionSet(caretCharPosition, caretCharPosition);
+                // set the selection position.
+                SelectionSet(caretCharPosition, caretCharPosition);
 
-                    // reset the caret blink timer.
-                    CaretResetBlink();
+                // reset the caret blink timer.
+                CaretResetBlink();
 
-                    // set the selection end position.
-                    SelectionSetEnd(caretCharPosition);
-                    break;
+                // set the selection end position.
+                SelectionSetEnd(caretCharPosition);
+            }
+            else if (button == 1)
+            {
+                // right-clicking is a shortcut to select all text.
+                CaretSelectAll();
             }
         }
 

--- a/Scripts/ShapeEditor/Windows/BottomToolbarWindow.cs
+++ b/Scripts/ShapeEditor/Windows/BottomToolbarWindow.cs
@@ -27,16 +27,13 @@ namespace AeternumGames.ShapeEditor
 
             Add(statusLabel = new GuiLabel("", new float2(7f, 4f), new float2(200, 20)));
 
-            Add(gridZoomTextbox = new GuiFloatTextbox(new float2(50, 16))
-                { allowNegativeNumbers = false, selectAllOnFocus = true });
+            Add(gridZoomTextbox = new GuiFloatTextbox(new float2(50, 16)) { allowNegativeNumbers = false });
             Add(gridZoomLabel = new GuiLabel("Zoom:", new float2(32, 20)));
             
-            Add(gridSnapTextbox = new GuiFloatTextbox(new float2(50, 16))
-                { allowNegativeNumbers = false, selectAllOnFocus = true, autoUpdateOnInput = true });
+            Add(gridSnapTextbox = new GuiFloatTextbox(new float2(50, 16)) { allowNegativeNumbers = false });
             Add(gridSnapLabel = new GuiLabel("Snap:", new float2(30, 20)));
             
-            Add(angleSnapTextbox = new GuiFloatTextbox(new float2(50, 16))
-                { allowNegativeNumbers = false, selectAllOnFocus = true, autoUpdateOnInput = true });
+            Add(angleSnapTextbox = new GuiFloatTextbox(new float2(50, 16)) { allowNegativeNumbers = false });
             Add(angleSnapLabel = new GuiLabel("Angle:", new float2(32, 20)));
 
             Add(snappingToggleButton = new GuiButton(resources.shapeEditorSnapping, 20, editor.UserToggleGridSnapping));

--- a/Scripts/ShapeEditor/Windows/BottomToolbarWindow.cs
+++ b/Scripts/ShapeEditor/Windows/BottomToolbarWindow.cs
@@ -29,10 +29,8 @@ namespace AeternumGames.ShapeEditor
 
             Add(gridZoomTextbox = new GuiFloatTextbox(new float2(50, 16)) { allowNegativeNumbers = false });
             Add(gridZoomLabel = new GuiLabel("Zoom:", new float2(32, 20)));
-            
             Add(gridSnapTextbox = new GuiFloatTextbox(new float2(50, 16)) { allowNegativeNumbers = false });
             Add(gridSnapLabel = new GuiLabel("Snap:", new float2(30, 20)));
-            
             Add(angleSnapTextbox = new GuiFloatTextbox(new float2(50, 16)) { allowNegativeNumbers = false });
             Add(angleSnapLabel = new GuiLabel("Angle:", new float2(32, 20)));
 

--- a/Scripts/ShapeEditor/Windows/BottomToolbarWindow.cs
+++ b/Scripts/ShapeEditor/Windows/BottomToolbarWindow.cs
@@ -27,11 +27,16 @@ namespace AeternumGames.ShapeEditor
 
             Add(statusLabel = new GuiLabel("", new float2(7f, 4f), new float2(200, 20)));
 
-            Add(gridZoomTextbox = new GuiFloatTextbox(new float2(50, 16)) { allowNegativeNumbers = false });
+            Add(gridZoomTextbox = new GuiFloatTextbox(new float2(50, 16))
+                { allowNegativeNumbers = false, selectAllOnFocus = true });
             Add(gridZoomLabel = new GuiLabel("Zoom:", new float2(32, 20)));
-            Add(gridSnapTextbox = new GuiFloatTextbox(new float2(50, 16)) { allowNegativeNumbers = false });
+            
+            Add(gridSnapTextbox = new GuiFloatTextbox(new float2(50, 16))
+                { allowNegativeNumbers = false, selectAllOnFocus = true, autoUpdateOnInput = true });
             Add(gridSnapLabel = new GuiLabel("Snap:", new float2(30, 20)));
-            Add(angleSnapTextbox = new GuiFloatTextbox(new float2(50, 16)) { allowNegativeNumbers = false });
+            
+            Add(angleSnapTextbox = new GuiFloatTextbox(new float2(50, 16))
+                { allowNegativeNumbers = false, selectAllOnFocus = true, autoUpdateOnInput = true });
             Add(angleSnapLabel = new GuiLabel("Angle:", new float2(32, 20)));
 
             Add(snappingToggleButton = new GuiButton(resources.shapeEditorSnapping, 20, editor.UserToggleGridSnapping));


### PR DESCRIPTION
Auto select all text on focus + Update Every Input.
Taken from Blender/Unity/RCSG, and set up for easily turning on and off to your content, possibly even depending on future user preferences. Currently only enabled on Bottom Toolbar text fields (angle, snap, zoom).
Also fixed an incorrect summary param description + made Keypad Enter work the same as Enter.