### PR TITLE
Button Fixes

### DIFF
--- a/Scripts/Editor/ShapeEditorWindow.Focus.cs
+++ b/Scripts/Editor/ShapeEditorWindow.Focus.cs
@@ -15,6 +15,9 @@ namespace AeternumGames.ShapeEditor
         /// <summary>Gets whether the active event receiver is a widget.</summary>
         internal bool activeEventReceiverIsWidget => activeEventReceiver is Widget;
 
+        /// <summary>Gets whether the active event receiver is a button.</summary>
+        internal bool activeEventReceiverIsButton => activeEventReceiver is GuiButton;
+        
         /// <summary>Gets whether the active event receiver is a tool.</summary>
         internal bool activeEventReceiverIsTool => activeEventReceiver is Tool;
 

--- a/Scripts/Editor/ShapeEditorWindow.cs
+++ b/Scripts/Editor/ShapeEditorWindow.cs
@@ -102,10 +102,7 @@ namespace AeternumGames.ShapeEditor
                         eventReceiver.OnMouseUp(button);
 
                         // try to focus the active tool.
-                        if (TrySwitchActiveEventReceiver(activeTool))
-                        {
-                            eventReceiver = activeTool;
-                        }
+                        if (TrySwitchActiveEventReceiver(activeTool));
                     }
                     else
                     {
@@ -124,6 +121,7 @@ namespace AeternumGames.ShapeEditor
         private void OnGlobalMouseUp(int button)
         {
             var eventReceiver = GetActiveEventReceiver();
+            bool switchToTool = false;
 
             // when the event receiver is busy it has exclusive rights to this event.
             if (eventReceiver.IsBusy())
@@ -137,26 +135,24 @@ namespace AeternumGames.ShapeEditor
                 {
                     var widget = GetActiveEventReceiver<Widget>();
                     if (!widget.wantsActive)
-                    {
-                        eventReceiver.OnGlobalMouseUp(button);
+                        switchToTool = true;
+                }
 
-                        // try to focus the active tool.
-                        if (TrySwitchActiveEventReceiver(activeTool))
-                        {
-                            eventReceiver = activeTool;
-                        }
-                    }
-                    else
-                    {
-                        eventReceiver.OnGlobalMouseUp(button);
-                    }
-                }
-                else
-                {
-                    eventReceiver.OnGlobalMouseUp(button);
-                }
+                // dispatch event
+                eventReceiver.OnGlobalMouseUp(button);
             }
 
+            // handles buttons auto losing focus
+            if (activeEventReceiverIsButton)
+                switchToTool = true;
+
+
+            // try to focus the active tool when requested.
+            if (switchToTool)
+            {
+                TrySwitchActiveEventReceiver(activeTool);
+            }
+            
             Repaint();
         }
 

--- a/Scripts/ShapeEditor/Gui/GuiButton.cs
+++ b/Scripts/ShapeEditor/Gui/GuiButton.cs
@@ -127,12 +127,12 @@ namespace AeternumGames.ShapeEditor
 
         public override void OnGlobalMouseUp(int button)
         {
-            if (button == 0)
+            if (button == 0 && isPressed)
             {
                 isPressed = false;
 
-                if (isMouseOver && onClick != null)
-                    onClick();
+                if (isMouseOver)
+                    onClick?.Invoke();
             }
         }
 


### PR DESCRIPTION
Makes it so that pressing a button doesn't retain focus on that button without clicking on the grid again.
+ Null prop check for onClick Action.